### PR TITLE
fix(security): SG-4356 — prevent payment amount parameter manipulation

### DIFF
--- a/Backend/src/api/controller/index.js
+++ b/Backend/src/api/controller/index.js
@@ -6,10 +6,13 @@ const { logTransaction, getTransaction } = require("../firebase");
 // Prevents frontend from tampering with the amount between init and submit
 const pendingOrders = new Map();
 
-const HMAC_SECRET = process.env.PAYMENT_HMAC_SECRET || "piimh-payment-secret-change-in-prod";
+const HMAC_SECRET = process.env.PAYMENT_HMAC_SECRET;
+if (!HMAC_SECRET) {
+  console.error("FATAL: PAYMENT_HMAC_SECRET env var is not set. Payment integrity checks will fail.");
+}
 
-// #2 — Generate HMAC hash of orderId + amount so backend can verify it wasn't tampered
 const generateAmountHash = (orderId, amount) => {
+  if (!HMAC_SECRET) throw new Error("PAYMENT_HMAC_SECRET env var is not configured");
   return crypto
     .createHmac("sha256", HMAC_SECRET)
     .update(`${orderId}:${amount}`)
@@ -93,6 +96,10 @@ const getFrontendBaseUrl = (req) => {
 // #2 — New endpoint: frontend calls this first to register the order amount server-side
 // Returns a hash the frontend must pass with the payment request
 const initPaymentOrder = (req, res) => {
+  if (!HMAC_SECRET) {
+    return res.status(500).json({ success: false, message: "Server configuration error" });
+  }
+
   const { orderId, amount } = req.body;
 
   if (!orderId || !amount) {
@@ -243,10 +250,11 @@ const createHdfcSession = async (req, res) => {
       pendingOrders.set(orderId, { ...existing, submitting: false });
     }
 
-    if (orderId && req.body?.amount) {
+    const failedPending = orderId ? pendingOrders.get(orderId) : null;
+    if (orderId && failedPending?.amount) {
       await logTransaction({
         orderId,
-        amount: req.body.amount,
+        amount: failedPending.amount,
         status: "Failed",
         responseHash: null,
         additionalData: {
@@ -513,7 +521,7 @@ const hdfcPaymentCallback = async (req, res) => {
 
     const logResult = await logTransaction({
       orderId: order_id,
-      amount: paidAmount || 1,
+      amount: paidAmount || null,
       status: logStatus,
       responseHash: transactionRef,
       additionalData: {

--- a/netlify/functions/hdfc-create-session.js
+++ b/netlify/functions/hdfc-create-session.js
@@ -1,4 +1,5 @@
 const axios = require("axios");
+const crypto = require("crypto");
 const admin = require("firebase-admin");
 
 if (!admin.apps.length) {
@@ -17,6 +18,39 @@ if (!admin.apps.length) {
     console.error("Firebase init failed:", err.message);
   }
 }
+
+/**
+ * Verify the HMAC the client echoes back matches what the server generated
+ * in init-order for this (orderId, amount) pair.
+ */
+const verifyAmountHash = (orderId, amount, amountHash) => {
+  const secret = process.env.PAYMENT_HMAC_SECRET || "piimh-payment-secret-change-in-prod";
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(`${orderId}:${amount}`)
+    .digest("hex");
+  // Constant-time comparison to prevent timing attacks
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(amountHash, "hex"));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Retrieve the authoritative amount written by init-order.
+ * Returns null if not found.
+ */
+const getInitAmountFromFirebase = async (orderId) => {
+  try {
+    if (!admin.apps.length) return null;
+    const snap = await admin.firestore().collection("transactions").doc(String(orderId)).get();
+    if (snap.exists && snap.data().amount) return Number(snap.data().amount);
+  } catch (err) {
+    console.warn("Firebase init-amount lookup failed:", err.message);
+  }
+  return null;
+};
 
 const saveAmountToFirebase = async (orderId, amount) => {
   try {
@@ -82,7 +116,8 @@ exports.handler = async (event) => {
     }
 
     const {
-      amount,
+      amount: clientAmount,
+      amountHash,
       customerId,
       customerEmail,
       customerPhone,
@@ -93,7 +128,7 @@ exports.handler = async (event) => {
 
     console.log("Request Parameters:", {
       orderId,
-      amount,
+      clientAmount,
       customerId,
       customerEmail,
       customerPhone,
@@ -101,8 +136,8 @@ exports.handler = async (event) => {
       lastName,
     });
 
-    // Validate required fields
-    const requiredFields = { orderId, amount, customerId, customerEmail, customerPhone };
+    // Validate required fields (amount still required from client so legacy flows aren't broken)
+    const requiredFields = { orderId, amount: clientAmount, customerId, customerEmail, customerPhone };
     const missingFields = Object.entries(requiredFields)
       .filter(([key, value]) => !value)
       .map(([key]) => key);
@@ -112,7 +147,7 @@ exports.handler = async (event) => {
       return {
         statusCode: 400,
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
+        body: JSON.stringify({
           success: false,
           message: `Missing required fields: ${missingFields.join(", ")}`,
           missingFields
@@ -121,6 +156,56 @@ exports.handler = async (event) => {
     }
 
     console.log("✓ All required fields present");
+
+    // ── Amount integrity check (SG-4356) ────────────────────────────────────
+    // 1. Look up the authoritative amount stored during init-order.
+    // 2. Verify the HMAC the client echoes back.
+    // 3. Use the server-side amount for all downstream operations — never the
+    //    raw client-supplied value.
+
+    const storedAmount = await getInitAmountFromFirebase(orderId);
+
+    if (storedAmount === null) {
+      console.error(`✗ No server-side amount record found for orderId [${orderId}]. Rejecting.`);
+      return {
+        statusCode: 400,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          success: false,
+          message: "Invalid or expired order. Please restart the payment flow.",
+        }),
+      };
+    }
+
+    // Verify HMAC if the client supplied one (required for new clients)
+    if (!amountHash) {
+      console.error(`✗ Missing amountHash for orderId [${orderId}]`);
+      return {
+        statusCode: 400,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          success: false,
+          message: "Missing amountHash. Payment integrity check failed.",
+        }),
+      };
+    }
+
+    if (!verifyAmountHash(orderId, storedAmount, amountHash)) {
+      console.error(`✗ HMAC mismatch for orderId [${orderId}]. Possible tampering. clientAmount=${clientAmount}, storedAmount=${storedAmount}`);
+      return {
+        statusCode: 400,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          success: false,
+          message: "Payment amount integrity check failed. Please restart the payment flow.",
+        }),
+      };
+    }
+
+    // Use the server-verified amount from this point on
+    const amount = storedAmount;
+    console.log(`✓ Amount integrity verified for [${orderId}]: ${amount} (client sent: ${clientAmount})`);
+    // ── End amount integrity check ───────────────────────────────────────────
 
     // Validate environment variables
     const hdfc_base_url = process.env.HDFC_BASE_URL;

--- a/netlify/functions/hdfc-create-session.js
+++ b/netlify/functions/hdfc-create-session.js
@@ -24,12 +24,12 @@ if (!admin.apps.length) {
  * in init-order for this (orderId, amount) pair.
  */
 const verifyAmountHash = (orderId, amount, amountHash) => {
-  const secret = process.env.PAYMENT_HMAC_SECRET || "piimh-payment-secret-change-in-prod";
+  const secret = process.env.PAYMENT_HMAC_SECRET;
+  if (!secret) throw new Error("PAYMENT_HMAC_SECRET env var is not configured");
   const expected = crypto
     .createHmac("sha256", secret)
     .update(`${orderId}:${amount}`)
     .digest("hex");
-  // Constant-time comparison to prevent timing attacks
   try {
     return crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(amountHash, "hex"));
   } catch {
@@ -96,6 +96,15 @@ exports.handler = async (event) => {
   }
 
   try {
+    if (!process.env.PAYMENT_HMAC_SECRET) {
+      console.error("PAYMENT_HMAC_SECRET is not set");
+      return {
+        statusCode: 500,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ success: false, message: "Server configuration error" }),
+      };
+    }
+
     console.log("Raw event body:", event.body);
     
     let parsedBody;

--- a/netlify/functions/hdfc-init-order.js
+++ b/netlify/functions/hdfc-init-order.js
@@ -1,4 +1,22 @@
 const crypto = require("crypto");
+const admin = require("firebase-admin");
+
+if (!admin.apps.length) {
+  try {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        type: "service_account",
+        project_id: process.env.FIREBASE_PROJECT_ID,
+        private_key_id: process.env.FIREBASE_PRIVATE_KEY_ID,
+        private_key: (process.env.FIREBASE_PRIVATE_KEY || "").replace(/\\n/g, "\n"),
+        client_email: process.env.FIREBASE_CLIENT_EMAIL,
+        client_id: process.env.FIREBASE_CLIENT_ID,
+      }),
+    });
+  } catch (err) {
+    console.error("Firebase init failed:", err.message);
+  }
+}
 
 const generateAmountHash = (orderId, amount) => {
   const secret = process.env.PAYMENT_HMAC_SECRET || "piimh-payment-secret-change-in-prod";
@@ -6,6 +24,30 @@ const generateAmountHash = (orderId, amount) => {
     .createHmac("sha256", secret)
     .update(`${orderId}:${amount}`)
     .digest("hex");
+};
+
+/**
+ * Persist the authoritative amount to Firestore so create-session can
+ * retrieve it server-side instead of trusting the client-supplied value.
+ */
+const saveInitAmountToFirebase = async (orderId, amount) => {
+  try {
+    if (!admin.apps.length) return;
+    const db = admin.firestore();
+    await db.collection("transactions").doc(String(orderId)).set(
+      {
+        orderId: String(orderId),
+        amount: Number(amount),
+        status: "Initiated",
+        lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+    console.log(`Init amount ${amount} saved to Firebase for [${orderId}]`);
+  } catch (err) {
+    // Non-fatal — HMAC check in create-session is the primary defence
+    console.warn("Firebase init-amount save failed:", err.message);
+  }
 };
 
 const jsonHeaders = {
@@ -76,6 +118,9 @@ exports.handler = async (event) => {
     }
 
     const amountHash = generateAmountHash(orderId, parsedAmount);
+
+    // Persist authoritative amount server-side before returning to client
+    await saveInitAmountToFirebase(orderId, parsedAmount);
 
     return {
       statusCode: 200,

--- a/netlify/functions/hdfc-init-order.js
+++ b/netlify/functions/hdfc-init-order.js
@@ -19,7 +19,8 @@ if (!admin.apps.length) {
 }
 
 const generateAmountHash = (orderId, amount) => {
-  const secret = process.env.PAYMENT_HMAC_SECRET || "piimh-payment-secret-change-in-prod";
+  const secret = process.env.PAYMENT_HMAC_SECRET;
+  if (!secret) throw new Error("PAYMENT_HMAC_SECRET env var is not configured");
   return crypto
     .createHmac("sha256", secret)
     .update(`${orderId}:${amount}`)
@@ -80,6 +81,15 @@ exports.handler = async (event) => {
   }
 
   try {
+    if (!process.env.PAYMENT_HMAC_SECRET) {
+      console.error("PAYMENT_HMAC_SECRET is not set");
+      return {
+        statusCode: 500,
+        headers: jsonHeaders,
+        body: JSON.stringify({ success: false, message: "Server configuration error" }),
+      };
+    }
+
     const body = event.body ? JSON.parse(event.body) : {};
     const { orderId, amount } = body;
     const parsedAmount = Number(amount);

--- a/netlify/functions/hdfc-payment-callback.js
+++ b/netlify/functions/hdfc-payment-callback.js
@@ -35,7 +35,7 @@ const saveToFirebase = async (orderId, amount, status, transactionRef, hdfcData)
     const d = hdfcData || {};
     const doc = {
       orderId: String(orderId),
-      amount: Number(amount) || 1,
+      amount: Number(amount) || null,
       status,
       responseHash: transactionRef || null,
       lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
@@ -188,11 +188,23 @@ exports.handler = async (event) => {
 
   // ── Paid-amount integrity check (SG-4356) ───────────────────────────────
   // Use the HDFC-confirmed amount as the source of truth.
-  // If it deviates from what we stored server-side, flag and block success.
+  // Block success if we cannot verify the amount against our stored record.
   const hdfcConfirmedAmount = hdfcOrderData.amount ? Number(hdfcOrderData.amount) : null;
 
-  if (isSuccess && storedAmount && hdfcConfirmedAmount !== null) {
-    if (Math.abs(hdfcConfirmedAmount - storedAmount) > 0.01) {
+  if (isSuccess) {
+    // If Firebase has no stored amount, we cannot verify — reject to be safe
+    if (!storedAmount) {
+      console.error(
+        `✗ NO STORED AMOUNT for [${order_id}]: cannot verify paid amount. Marking as Tampered.`
+      );
+      await saveToFirebase(order_id, hdfcConfirmedAmount || paidAmount, "Tampered", transactionRef, hdfcOrderData);
+      return {
+        statusCode: 302,
+        headers: { Location: `${FRONTEND_URL}/payment-status?error=amount_mismatch&order_id=${order_id}` },
+      };
+    }
+
+    if (hdfcConfirmedAmount !== null && Math.abs(hdfcConfirmedAmount - storedAmount) > 0.01) {
       console.error(
         `✗ AMOUNT MISMATCH for [${order_id}]: HDFC confirmed ${hdfcConfirmedAmount}, stored ${storedAmount}. Marking as Tampered.`
       );

--- a/netlify/functions/hdfc-payment-callback.js
+++ b/netlify/functions/hdfc-payment-callback.js
@@ -154,12 +154,14 @@ exports.handler = async (event) => {
   const logStatus = isSuccess ? "Success" : "Failed";
   const transactionRef = hash || signature || null;
 
-  // Amount from callback, fallback to Firebase
+  // Retrieve authoritative amount written during init-order / create-session
+  const storedAmount = await getAmountFromFirebase(order_id);
+
+  // Amount from callback, fallback to stored amount
   let paidAmount = Number(amount || 0);
-  if (!paidAmount) {
-    const fbAmount = await getAmountFromFirebase(order_id);
-    if (fbAmount) paidAmount = fbAmount;
-    console.log(`Amount from Firebase for [${order_id}]:`, fbAmount);
+  if (!paidAmount && storedAmount) {
+    paidAmount = storedAmount;
+    console.log(`Amount from Firebase for [${order_id}]:`, storedAmount);
   }
 
   // Fetch full order data from HDFC Status API
@@ -183,6 +185,28 @@ exports.handler = async (event) => {
   } catch (err) {
     console.warn(`HDFC Status API failed for [${order_id}]: ${err.message}`);
   }
+
+  // ── Paid-amount integrity check (SG-4356) ───────────────────────────────
+  // Use the HDFC-confirmed amount as the source of truth.
+  // If it deviates from what we stored server-side, flag and block success.
+  const hdfcConfirmedAmount = hdfcOrderData.amount ? Number(hdfcOrderData.amount) : null;
+
+  if (isSuccess && storedAmount && hdfcConfirmedAmount !== null) {
+    if (Math.abs(hdfcConfirmedAmount - storedAmount) > 0.01) {
+      console.error(
+        `✗ AMOUNT MISMATCH for [${order_id}]: HDFC confirmed ${hdfcConfirmedAmount}, stored ${storedAmount}. Marking as Tampered.`
+      );
+      await saveToFirebase(order_id, hdfcConfirmedAmount, "Tampered", transactionRef, hdfcOrderData);
+      return {
+        statusCode: 302,
+        headers: { Location: `${FRONTEND_URL}/payment-status?error=amount_mismatch&order_id=${order_id}` },
+      };
+    }
+  }
+
+  // Use the HDFC-confirmed amount for the final record when available
+  if (hdfcConfirmedAmount) paidAmount = hdfcConfirmedAmount;
+  // ── End paid-amount integrity check ─────────────────────────────────────
 
   // Save everything to Firebase
   await saveToFirebase(order_id, paidAmount, logStatus, transactionRef, hdfcOrderData);


### PR DESCRIPTION
## Problem
The backend trusted the client-supplied amount in /hdfc/create-session without any server-side validation. An attacker could intercept the request and change the amount to any lower value, completing a purchase for far less than the actual price.

OWASP A01:2025 Broken Access Control / CWE-472 parameter tampering.

## Changes

### hdfc-init-order.js
- Persist authoritative (orderId, amount) to Firestore as status 'Initiated' — this becomes the server-side source of truth.

### hdfc-create-session.js
- Require amountHash in request; reject 400 if absent.
- verifyAmountHash(): constant-time HMAC-SHA256 comparison.
- getInitAmountFromFirebase(): look up amount written by init-order.
- Reject if Firestore record missing (blocks calls that skip init-order).
- Use storedAmount for HDFC payload — client-supplied value is discarded.

### hdfc-payment-callback.js
- Compare HDFC-confirmed amount vs Firestore-stored amount at callback.
- If mismatch > 0.01, mark transaction 'Tampered' and redirect to error.
- Use HDFC-confirmed amount as final record.

Fixes: SG-4356