### PR TITLE
Remove amount from HDFC payment request payload

### DIFF
--- a/src/Pages/HdfcPayment.jsx
+++ b/src/Pages/HdfcPayment.jsx
@@ -111,7 +111,6 @@ const HdfcPaymentForm = () => {
       const requestPayload = {
         ...form,
         orderId,
-        amount,
         amountHash: initData.amountHash,
       };
 


### PR DESCRIPTION
Removed the 'amount' field from the request payload for HDFC payment.